### PR TITLE
fstab.armani: add noemulatedsd flag

### DIFF
--- a/rootdir/etc/fstab.armani
+++ b/rootdir/etc/fstab.armani
@@ -11,7 +11,7 @@
 /dev/block/platform/msm_sdcc.1/by-name/boot         /boot          emmc      defaults                                                     defaults
 /dev/block/platform/msm_sdcc.1/by-name/recovery     /recovery      emmc      defaults                                                     defaults
 
-/devices/msm_sdcc.2/mmc_host*                       auto           auto      defaults                                                     voldmanaged=sdcard1:auto
+/devices/msm_sdcc.2/mmc_host*                       auto           auto      defaults                                                     voldmanaged=sdcard1:auto,noemulatedsd
 /devices/platform/msm_hsusb_host/usb1               auto           auto      defaults                                                     voldmanaged=usbdisk:auto
 
 /dev/block/zram0                                    none           swap      defaults                                                     zramsize=268435456


### PR DESCRIPTION
fixes moving apps to external sdcard

ref: https://github.com/temasek/android_device_samsung_hlte-common/commit/3d242e371728edeef1909fefd62265e70199c84f